### PR TITLE
Add an envvar-based switch for local-only listener

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,4 +39,5 @@ app.all('*', function (req, res) {
 	res.redirect('https://github.com/besoeasy/nanonodeagent');
 });
 
-app.listen(process.env.PORT || 5000, '0.0.0.0');
+app.listen(process.env.PORT || 5000, process.env.PUBLIC == 'true' ? '0.0.0.0': '127.0.0.1');
+


### PR DESCRIPTION
This change makes local-only listener possible without the need for an
additional firewall rule

To use it with the original, public listening on 0.0.0.0, simply execute:

`PUBLIC=true npm start`